### PR TITLE
Enable replacement of millis() function (II)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Kaleidoscope-Hardware-Virtual
 
+### NOTE: This repository is no longer active; development has moved to [the `keyboardio` org][kbrepo].
+
 This is a plugin for [Kaleidoscope][fw], targeted at **developers** (of Kaleidoscope
 or plugins for Kaleidoscope).  It allows you to test Kaleidoscope sketches,
 plugins, and changes to the core without physical hardware.  This has several
@@ -113,3 +115,4 @@ If you have feature requests or issues to report, again feel free to open issues
 GitHub!
 
  [fw]: https://github.com/keyboardio/Kaleidoscope
+ [kbrepo]: https://github.com/keyboardio/Kaleidoscope-Hardware-Virtual

--- a/support/x86/cores/virtual/Arduino.c
+++ b/support/x86/cores/virtual/Arduino.c
@@ -2,6 +2,7 @@
 
 // TODO: better time emulation
 // this is pretty hacky, but hopefully helps most code behave sanely
+__attribute__((weak))
 unsigned long millis(void) {
   static unsigned long time = 0;
   return time++;


### PR DESCRIPTION
For my Kaleidoscope-Python module that wraps Kaleidoscope-Hardware-Virtual I need to be able to replace the millis() function that does its own time handling. To achieve this, I turned the function into a weak symbol.