### PR TITLE
Enable replacement of millis() function (III)

### DIFF
--- a/support/x86/cores/virtual/Arduino.c
+++ b/support/x86/cores/virtual/Arduino.c
@@ -2,6 +2,7 @@
 
 // TODO: better time emulation
 // this is pretty hacky, but hopefully helps most code behave sanely
+// note: 'weak' attribute allows users to override with their own implementation of millis()
 __attribute__((weak))
 unsigned long millis(void) {
   static unsigned long time = 0;

--- a/support/x86/cores/virtual/Arduino.c
+++ b/support/x86/cores/virtual/Arduino.c
@@ -2,6 +2,7 @@
 
 // TODO: better time emulation
 // this is pretty hacky, but hopefully helps most code behave sanely
+__attribute__((weak))
 unsigned long millis(void) {
   static unsigned long time = 0;
   return time++;


### PR DESCRIPTION
For my Kaleidoscope-Python module that wraps Kaleidoscope-Hardware-Virtual I need to be able to replace the millis() function that does its own time handling. To achieve this, I turned the function into a weak symbol.