### PR TITLE
Added function based printf log output

### DIFF
--- a/src/Kaleidoscope-Hardware-Virtual.cpp
+++ b/src/Kaleidoscope-Hardware-Virtual.cpp
@@ -19,9 +19,11 @@
 #include <Kaleidoscope.h>
 #include "Kaleidoscope-Hardware-Virtual.h"
 #include "virtual_io.h"
-#include <iostream>
+#include "Logging.h"
 #include <sstream>
 #include <string>
+
+using namespace kaleidoscope::logging;
 
 Virtual::Virtual(void) 
    :  _readMatrixEnabled(true)
@@ -93,20 +95,20 @@ void Virtual::readMatrix() {
       if(token.front() == '(' && token.back() == ')') {
         size_t commapos = token.find_first_of(',');
         if(commapos == std::string::npos) {
-          std::cout << "Bad (r,c) pair: " << token << std::endl;
+          log_error("Bad (r,c) pair: %s\n", token.c_str());
           continue;
         } else {
           key.row = std::stoi(token.substr(1,commapos-1));
           key.col = std::stoi(token.substr(commapos+1,token.length()-commapos-1));
           if(key.row >= ROWS || key.col >= COLS) {
-            std::cout << "Bad coordinates: " << token << std::endl;
+            log_error("Bad coordinates: %s\n", token.c_str());
             continue;
           }
         }
       } else {
         key = getRCfromPhysicalKey(token);
         if(key.row >= ROWS || key.col >= COLS) {
-          std::cout << "Unrecognized command: " << token << std::endl;
+          log_error("Unrecognized command: %s\n", token.c_str());
           continue;
         }
       }
@@ -132,7 +134,7 @@ void Virtual::actOnMatrixScan() {
           keyState |= WAS_PRESSED;
           break;
         case TAP:
-          std::cerr << "Error: assertion failed, keystates_prev should not be TAP" << std::endl;
+          log_error("Error: assertion failed, keystates_prev should not be TAP\n");
           break;
         case NOT_PRESSED:
         default:

--- a/src/Logging.cpp
+++ b/src/Logging.cpp
@@ -1,0 +1,37 @@
+/* -*- mode: c++ -*-
+ * Kaleidoscope-Hardware-Virtual -- Test and debug Kaleidoscope sketches, plugins, and core
+ * Copyright (C) 2017  Craig Disselkoen
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "Logging.h"
+
+namespace kaleidoscope {
+namespace logging {
+   
+static bool __verboseOutputEnabled = true;
+
+void toggleVerboseOutput(bool state)
+{
+   __verboseOutputEnabled = state;
+}
+
+bool verboseOutputEnabled()
+{
+   return __verboseOutputEnabled;
+}
+
+} // namespace logging
+} // namespace kaleidoscope

--- a/src/Logging.h
+++ b/src/Logging.h
@@ -1,0 +1,94 @@
+/* -*- mode: c++ -*-
+ * Kaleidoscope-Hardware-Virtual -- Test and debug Kaleidoscope sketches, plugins, and core
+ * Copyright (C) 2017  Craig Disselkoen
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "utility"
+#include "stdio.h"
+
+namespace kaleidoscope {
+namespace logging {
+   
+extern void toggleVerboseOutput(bool state);
+extern bool verboseOutputEnabled();
+
+// Please note that we prefer stdio based logging against
+// stream based output, to stay compatible with possible future global 
+// logging functions introduced by Kaleidoscope. Stream
+// based logging is not available on the target platform due to restricted
+// resources.
+
+// Below, we use perfect forwarding to pass printf style log messages 
+// to different printf derivates. gcc warns when the the format string
+// is not a literal, which is not the case here due to our forwarding. 
+// To silence the related warning, which is not desired in our application,
+// we disable the format-security diagnostic until the end of this file.
+
+// Disable diagnostic for literal format strings.
+//
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wformat-security"
+
+#ifdef KALEIDOSCOPE_HARDWARE_VIRTUAL_NO_LOGGING
+
+template<typename... Args__>
+inline 
+void log_debug(Args__&&... args) {}
+
+template<typename... Args__>
+inline 
+void log_info(Args__&&... args) {}
+
+#else // #ifdef KALEIDOSCOPE_HARDWARE_VIRTUAL_NO_LOGGING
+
+template<typename... Args__>
+inline 
+void log_debug(Args__&&... args) {
+   if(verboseOutputEnabled()) {
+      fprintf(stdout, std::forward<Args__>(args)...);
+   }
+}
+
+template<typename... Args__>
+inline 
+void log_info(Args__&&... args) {
+   if(verboseOutputEnabled()) {
+      fprintf(stdout, std::forward<Args__>(args)...);
+   }
+}
+
+#endif // #ifdef KALEIDOSCOPE_HARDWARE_VIRTUAL_NO_LOGGING
+
+template<typename... Args__>
+inline 
+void log_error(Args__&&... args) {
+   fprintf(stderr, std::forward<Args__>(args)...);
+}
+
+template<typename... Args__>
+inline 
+void log_critical(Args__&&... args) {
+   fprintf(stderr, std::forward<Args__>(args)...);
+}
+
+} // namespace logging
+} // namespace kaleidoscope
+
+// Re-enable diagnostic for literal format strings.
+//
+#pragma GCC diagnostic pop

--- a/src/VirtualHID/ConsumerControl.cpp
+++ b/src/VirtualHID/ConsumerControl.cpp
@@ -1,6 +1,8 @@
 #include "ConsumerControl.h"
-#include <iostream>
+#include "Logging.h"
 #include "virtual_io.h"
+
+using namespace kaleidoscope::logging;
 
 ConsumerControl_::ConsumerControl_(void) {}
 void ConsumerControl_::begin(void) { end(); }
@@ -44,7 +46,7 @@ void ConsumerControl_::sendReport() {
 }
 
 void ConsumerControl_::sendReportUnchecked() {
-  std::cout << "A virtual ConsumerControl HID report was sent." << std::endl;
+  log_info("A virtual ConsumerControl HID report was sent.\n");
   logUSBEvent("ConsumerControl HID report", &_report, sizeof(_report));
 }
 

--- a/src/VirtualHID/Keyboard.cpp
+++ b/src/VirtualHID/Keyboard.cpp
@@ -1,8 +1,10 @@
 #include "Keyboard.h"
-#include <iostream>
+#include "Logging.h"
 #include <sstream>
 #include "virtual_io.h"
 #include <assert.h>
+
+using namespace kaleidoscope::logging;
 
 static StandardKeyboardReportConsumer standardKeyboardReportConsumer;
 
@@ -170,7 +172,7 @@ void StandardKeyboardReportConsumer::processKeyboardReport(
     }
   }
 
-  std::cout << "Sent virtual HID report. Pressed keys: " << keypresses.str() << std::endl;
+  log_info("Sent virtual HID report. Pressed keys: %s\n", keypresses.str().c_str());
   logUSBEvent_keyboard("Keyboard HID report; pressed keys: " + keypresses.str());
 }
 

--- a/src/VirtualHID/Mouse.cpp
+++ b/src/VirtualHID/Mouse.cpp
@@ -1,6 +1,8 @@
 #include "Mouse.h"
-#include <iostream>
+#include "Logging.h"
 #include "virtual_io.h"
+
+using namespace kaleidoscope::logging;
 
 Mouse_::Mouse_(void) {}
 void Mouse_::begin(void) { end(); }
@@ -48,7 +50,7 @@ void Mouse_::sendReport() {
 }
 
 void Mouse_::sendReportUnchecked() {
-  std::cout << "A virtual Mouse HID report was sent." << std::endl;
+  log_info("A virtual Mouse HID report was sent.\n");
   logUSBEvent("Mouse HID report", &report, sizeof(report));
 }
 

--- a/src/VirtualHID/SingleAbsoluteMouse.cpp
+++ b/src/VirtualHID/SingleAbsoluteMouse.cpp
@@ -1,11 +1,13 @@
 #include "SingleAbsoluteMouse.h"
-#include <iostream>
+#include "Logging.h"
 #include "virtual_io.h"
+
+using namespace kaleidoscope::logging;
 
 SingleAbsoluteMouse_::SingleAbsoluteMouse_(void) {}
 
 void SingleAbsoluteMouse_::sendReport(void* data, int length) {
-  std::cout << "A virtual SingleAbsoluteMouse HID report was sent." << std::endl;
+  log_info("A virtual SingleAbsoluteMouse HID report was sent.\n");
   logUSBEvent("SingleAbsoluteMouse HID report", data, length);
 }
 

--- a/src/VirtualHID/SystemControl.cpp
+++ b/src/VirtualHID/SystemControl.cpp
@@ -1,6 +1,8 @@
 #include "SystemControl.h"
-#include <iostream>
+#include "Logging.h"
 #include "virtual_io.h"
+
+using namespace kaleidoscope::logging;
 
 SystemControl_::SystemControl_(void) {}
 void SystemControl_::begin(void) { releaseAll(); }
@@ -22,7 +24,7 @@ void SystemControl_::press(uint8_t s) {
 }
 
 void SystemControl_::sendReport(void* data, int length) {
-  std::cout << "A virtual SystemControl HID report with value " << *(uint8_t*)data << " was sent." << std::endl;
+  log_info("A virtual SystemControl HID report with value %hhu was sent.\n", *(uint8_t*)data);
   logUSBEvent("SystemControl HID report", data, length);
 }
 


### PR DESCRIPTION
This is a follow up to https://github.com/keyboardio/Kaleidoscope-Hardware-Virtual/pull/3
In all c++ code files, iostream based logging is replaced by log functions, as proposed by @obra.

I implemented the logging functions in a way that they could possibly be lifted out to the Kaleidoscope core.

 `iostream` based output was replaced by `fprintf`, using perfect forwarding of the output.
`iostream` entities like `std::cout` and `std::endl` use costly stream based output under the hood, which - in contrast to `printf` - involves a lot of dynamic memory allocation.