### PR TITLE
Added a getter for keystates

### DIFF
--- a/src/Kaleidoscope-Hardware-Virtual.cpp
+++ b/src/Kaleidoscope-Hardware-Virtual.cpp
@@ -121,6 +121,10 @@ void Virtual::setKeystate(byte row, byte col, keystate ks) {
   keystates[row][col] = ks;
 }
 
+Virtual::keystate Virtual::getKeystate(byte row, byte col) const {
+  return keystates[row][col];
+}
+
 void Virtual::actOnMatrixScan() {
   for (byte row = 0; row < ROWS; row++) {
     for (byte col = 0; col < COLS; col++) {

--- a/src/Kaleidoscope-Hardware-Virtual.h
+++ b/src/Kaleidoscope-Hardware-Virtual.h
@@ -69,6 +69,7 @@ class Virtual {
   }
 
   void setKeystate(byte row, byte col, keystate ks);
+  keystate getKeystate(byte row, byte col) const;
 
  private:
 

--- a/support/x86/cores/virtual/Print.h
+++ b/support/x86/cores/virtual/Print.h
@@ -94,7 +94,9 @@ class Print {
   size_t println(const Printable&);
   size_t println(void);
 
-  virtual void flush() { /* Empty implementation for backward compatibility */ }
+  virtual void flush() {
+    /* Empty implementation for backward compatibility */
+  }
 };
 
 #endif


### PR DESCRIPTION
The Virtual class is providing a setter but no getter for keystates. This getter is important to find out if a key is pressed, e.g. during a regression test.