### PR TITLE
Emulate system LEDs (for reading numlock state) in a reasonable way

### DIFF
--- a/src/VirtualHID/Keyboard.h
+++ b/src/VirtualHID/Keyboard.h
@@ -58,6 +58,9 @@ class Keyboard_ {
   HID_KeyboardReport_Data_t _lastKeyReport;
 
   KeyboardReportConsumer_ *_keyboardReportConsumer;
+
+  uint8_t _systemLEDStates;  // returned by getLEDs
+  bool _numlockPressed;  // whether numlock is currently pressed
 };
 
 extern Keyboard_ Keyboard;


### PR DESCRIPTION
This more-reasonable emulation ensures at least more-correct numlock operation, following recent upstream changes in Kaleidoscope-Numlock.