### PR TITLE
Removed atexit

### DIFF
--- a/support/x86/cores/virtual/Arduino.h
+++ b/support/x86/cores/virtual/Arduino.h
@@ -129,8 +129,6 @@ typedef uint8_t byte;
 void init(void);
 void initVariant(void);
 
-int atexit(void (*func)()) __attribute__((weak));
-
 void pinMode(uint8_t, uint8_t);
 void digitalWrite(uint8_t, uint8_t);
 int digitalRead(uint8_t);

--- a/support/x86/cores/virtual/main.cpp
+++ b/support/x86/cores/virtual/main.cpp
@@ -21,11 +21,6 @@
 #include "virtual_io.h"
 #include <iostream>
 
-// Declared weak in Arduino.h to allow user redefinitions.
-int atexit(void (* /*func*/)()) throw () {
-  return 0;
-}
-
 // Weak empty variant initialization function.
 // May be redefined by variant files.
 void initVariant() __attribute__((weak));


### PR DESCRIPTION
The implementation of `atexit` supplied by KHV collides with
the definition in stdlib.h on some systems (e.g. when
compiled on MacOS 10.12 with XCode 8.3). The collision is because of __attribute__((weak)).

As far as I can see, it is only legal to declare a symbol weak at its first occurence.

What would a user defined atexit function be used for, anyway? If there is no particular reason for `atexit` being defined in KHV, I would suggest to simply remove it, which is what this PR does.