### PR TITLE
Added implementations of serial event functions

### DIFF
--- a/support/x86/cores/virtual/HardwareSerial.cpp
+++ b/support/x86/cores/virtual/HardwareSerial.cpp
@@ -15,10 +15,18 @@ void serialEvent() {}
 void serialEvent1() {}
 void serialEvent2() {}
 void serialEvent3() {}
-bool Serial0_available() { return true; }
-bool Serial1_available() { return true; }
-bool Serial2_available() { return true; }
-bool Serial3_available() { return true; }
+bool Serial0_available() {
+  return true;
+}
+bool Serial1_available() {
+  return true;
+}
+bool Serial2_available() {
+  return true;
+}
+bool Serial3_available() {
+  return true;
+}
 
 void serialEventRun(void) {
   if (Serial0_available()) serialEvent();

--- a/support/x86/cores/virtual/HardwareSerial.cpp
+++ b/support/x86/cores/virtual/HardwareSerial.cpp
@@ -11,11 +11,20 @@ bool Serial1_available() __attribute__((weak));
 bool Serial2_available() __attribute__((weak));
 bool Serial3_available() __attribute__((weak));
 
+void serialEvent() {}
+void serialEvent1() {}
+void serialEvent2() {}
+void serialEvent3() {}
+bool Serial0_available() { return true; }
+bool Serial1_available() { return true; }
+bool Serial2_available() { return true; }
+bool Serial3_available() { return true; }
+
 void serialEventRun(void) {
-  if (Serial0_available && serialEvent && Serial0_available()) serialEvent();
-  if (Serial1_available && serialEvent && Serial1_available()) serialEvent1();
-  if (Serial2_available && serialEvent && Serial2_available()) serialEvent2();
-  if (Serial3_available && serialEvent && Serial3_available()) serialEvent3();
+  if (Serial0_available()) serialEvent();
+  if (Serial1_available()) serialEvent1();
+  if (Serial2_available()) serialEvent2();
+  if (Serial3_available()) serialEvent3();
 }
 
 unsigned HardwareSerial::serialNumber = 0;


### PR DESCRIPTION
The follwing functions are undefined in KHV

```cpp
void serialEvent() __attribute__((weak));
void serialEvent1() __attribute__((weak));
void serialEvent2() __attribute__((weak));
void serialEvent3() __attribute__((weak));
bool Serial0_available() __attribute__((weak));
bool Serial1_available() __attribute__((weak));
bool Serial2_available() __attribute__((weak));
bool Serial3_available() __attribute__((weak));
```

this is not a problem when build as an executable with gcc. When build as part of a library, the code may need to be linked with `-force_load` (XCode). This may be necessary to suppress removal of unused symbols. In such a case, XCode reports the functions above as undefined symbols which is a linker error. To allow for such an use case, this PR implements the weak symbols and simplifies their use in `serialEventRun`.