### PR TITLE
library.properties: Change the category to Other

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -4,6 +4,6 @@ author=Craig Disselkoen
 maintainer=Craig Disselkoen <craigdissel@gmail.com>
 sentence=Test and debug Kaleidoscope sketches, plugins, and core
 paragraph=Test and debug Kaleidoscope sketches, plugins, and core
-category=Debug
+category=Other
 url=https://github.com/cdisselkoen/Kaleidoscope-Hardware-Virtual
 architectures=avr


### PR DESCRIPTION
Arduino does not have a Debug category, change it to Other to silence a very annoying warning.
