### PR TITLE
Transition to matrix addressing of keys and LEDs

### DIFF
--- a/src/Kaleidoscope-Hardware-Virtual.cpp
+++ b/src/Kaleidoscope-Hardware-Virtual.cpp
@@ -123,18 +123,18 @@ void Virtual::readMatrix() {
   }
 }
 
-void Virtual::setKeystate(byte row, byte col, keystate ks) {
-  keystates[row][col] = ks;
+void Virtual::setKeystate(KeyAddr keyAddr, keystate ks) {
+  keystates[keyAddr.row()][keyAddr.col()] = ks;
 }
 
 void Virtual::setKeyscanInterval(uint8_t interval) {
-	// TODO implement;
-return;
+  // TODO implement;
+  return;
 
 }
 
-Virtual::keystate Virtual::getKeystate(byte row, byte col) const {
-  return keystates[row][col];
+Virtual::keystate Virtual::getKeystate(KeyAddr keyAddr) const {
+  return keystates[keyAddr.row()][keyAddr.col()];
 }
 
 void Virtual::actOnMatrixScan() {
@@ -163,11 +163,11 @@ void Virtual::actOnMatrixScan() {
         /* do nothing */
         break;
       }
-      handleKeyswitchEvent(Key_NoKey, row, col, keyState);
+      handleKeyswitchEvent(Key_NoKey, KeyAddr(row, col), keyState);
       keystates_prev[row][col] = keystates[row][col];
       if (keystates[row][col] == TAP) {
         keyState = WAS_PRESSED & ~IS_PRESSED;
-        handleKeyswitchEvent(Key_NoKey, row, col, keyState);
+        handleKeyswitchEvent(Key_NoKey, KeyAddr(row, col), keyState);
         keystates[row][col] = NOT_PRESSED;
         keystates_prev[row][col] = NOT_PRESSED;
       }
@@ -175,17 +175,17 @@ void Virtual::actOnMatrixScan() {
   }
 }
 
-bool Virtual::isKeyswitchPressed(byte row, byte col) {
-  if (keystates[row][col] == NOT_PRESSED) {
-	return false; 
+bool Virtual::isKeyswitchPressed(KeyAddr keyAddr) {
+  if (keystates[keyAddr.row()][keyAddr.col()] == NOT_PRESSED) {
+    return false;
 
   }
- return true;
+  return true;
 }
 
 bool Virtual::isKeyswitchPressed(uint8_t keyIndex) {
   keyIndex--;
-  return isKeyswitchPressed(keyIndex / COLS, keyIndex % COLS);
+  return isKeyswitchPressed(KeyAddr(keyIndex));
 }
 
 
@@ -257,20 +257,20 @@ static rc getRCfromPhysicalKey(std::string keyname) {
   return {255, 255};
 }
 
-void Virtual::maskKey(byte row, byte col) {
-  if (row >= ROWS || col >= COLS)
+void Virtual::maskKey(KeyAddr keyAddr) {
+  if (!keyAddr.isValid())
     return;
   mask[row][col] = true;
 }
 
-void Virtual::unMaskKey(byte row, byte col) {
-  if (row >= ROWS || col >= COLS)
+void Virtual::unMaskKey(KeyAddr keyAddr) {
+  if (!keyAddr.isValid())
     return;
   mask[row][col] = false;
 }
 
-bool Virtual::isKeyMasked(byte row, byte col) {
-  if (row >= ROWS || col >= COLS)
+bool Virtual::isKeyMasked(KeyAddr keyAddr) {
+  if (!keyAddr.isValid())
     return false;
   return mask[row][col];
 }
@@ -295,16 +295,16 @@ void Virtual::syncLeds(void) {
   logLEDStates(ss.str());
 }
 
-void Virtual::setCrgbAt(byte row, byte col, cRGB color) {
-  setCrgbAt(row * COLS + col, color);
+void Virtual::setCrgbAt(LEDAddr ledAddr, cRGB color) {
+  setCrgbAt(ledAddr.offset(), color);
 }
 
 void Virtual::setCrgbAt(byte i, cRGB color) {
   ledStates[i] = color;
 }
 
-cRGB Virtual::getCrgbAt(byte row, byte col) const {
-  return getCrgbAt(row * COLS + col);
+cRGB Virtual::getCrgbAt(LEDAddr ledAddr) const {
+  return getCrgbAt(ledAddr.offset());
 }
 
 cRGB Virtual::getCrgbAt(byte i) const {
@@ -312,12 +312,12 @@ cRGB Virtual::getCrgbAt(byte i) const {
 }
 
 void Virtual::attachToHost(void) {
-	return;
-	// TODO - stub implementation
+  return;
+  // TODO - stub implementation
 }
 void Virtual::detachFromHost(void)  {
-	return;
-	// TODO - stub implementation
+  return;
+  // TODO - stub implementation
 }
 
 HARDWARE_IMPLEMENTATION KeyboardHardware;

--- a/src/Kaleidoscope-Hardware-Virtual.h
+++ b/src/Kaleidoscope-Hardware-Virtual.h
@@ -52,16 +52,33 @@ class Virtual {
   void readMatrix(void);
   void actOnMatrixScan(void);
 
-  void maskKey(byte row, byte col);
-  void unMaskKey(byte row, byte col);
-  bool isKeyMasked(byte row, byte col);
+  void maskKey(KeyAddr keyAddr);
+  KS_ROW_COL_FUNC void maskKey(byte row, byte col) {
+    maskKey(KeyAddr(row, col));
+  }
+
+  void unMaskKey(KeyAddr keyAddr);
+  KS_ROW_COL_FUNC void unMaskKey(byte row, byte col) {
+    unMaskKey(KeyAddr(row, col));
+  }
+
+  bool isKeyMasked(KeyAddr keyAddr);
+  KS_ROW_COL_FUNC bool isKeyMasked(byte row, byte col) {
+    return isKeyMasked(KeyAddr(row, col));
+  }
   void maskHeldKeys(void);
 
   // For virtual hardware, the current state of all LEDs will be logged to a dedicated file in results upon each call to syncLeds()
   void syncLeds(void);
-  void setCrgbAt(byte /*row*/, byte /*col*/, cRGB /*color*/);
+  void setCrgbAt(LEDAddr /*ledAddr*/, cRGB /*color*/);
+  KS_ROW_COL_FUNC void setCrgbAt(byte row, byte col, cRGB /*color*/) {
+    setCrgbAt(LEDAddr(row, col));
+  }
   void setCrgbAt(uint8_t /*i*/, cRGB /*color*/);
-  cRGB getCrgbAt(byte /*row*/, byte /*col*/) const;  // not part of the official Kaleidoscope-Hardware API, but an extension we use here
+  cRGB getCrgbAt(LEDAddr /*ledAddr*/) const;// not part of the official Kaleidoscope-Hardware API, but an extension we use here
+  KS_ROW_COL_FUNC cRGB getCrgbAt(byte row, byte col) const {
+    return getCrgbAt(LEDAddr(row, col));
+  }
   cRGB getCrgbAt(uint8_t /*i*/) const;
 
   void scanMatrix(void) {
@@ -73,8 +90,16 @@ class Virtual {
     _readMatrixEnabled = state;
   }
 
-  void setKeystate(byte row, byte col, keystate ks);
-  keystate getKeystate(byte row, byte col) const;
+  void setKeystate(KeyAddr keyAddr, keystate ks);
+  KS_ROW_COL_FUNC void setKeystate(byte row, byte col, keystate ks) {
+    setKeystate(KeyAddr(row, col), ks);
+  }
+
+  keystate getKeystate(KeyAddr keyAddr) const;
+  KS_ROW_COL_FUNC keystate getKeystate(byte row, byte col) const {
+    return getKeystate(KeyAddr(row, col));
+  }
+
   void attachToHost(void);
   void detachFromHost(void);
   void setKeyscanInterval(uint8_t interval);
@@ -88,6 +113,14 @@ class Virtual {
    * pressed keys.
    */
   /**
+  * Check if a key is pressed at a given position.
+  *
+  * @param keyAddr the matrix address of the key.
+  *
+  * @returns true if the key is pressed, false otherwise.
+  */
+  bool isKeyswitchPressed(KeyAddr keyAddr);
+  /**
    * Check if a key is pressed at a given position.
    *
    * @param row is the row the key is located at in the matrix.
@@ -95,7 +128,9 @@ class Virtual {
    *
    * @returns true if the key is pressed, false otherwise.
    */
-  bool isKeyswitchPressed(byte row, byte col);
+  KS_ROW_COL_FUNC bool isKeyswitchPressed(byte row, byte col) {
+    return isKeyswitchPressed(KeyAddr(row, col));
+  }
   /**
    * Check if a key is pressed at a given position.
    *
@@ -140,8 +175,11 @@ class Virtual {
  * zero. We can use this to avoid having to explicitly add a sentinel in
  * user-facing code.
  */
-constexpr byte keyIndex(byte row, byte col) {
-  return row * COLS + col + 1;
+constexpr byte keyIndex(KeyAddr keyAddr) {
+  return keyAddr.offset() + 1;
+}
+KS_ROW_COL_FUNC constexpr byte keyIndex(byte row, byte col) {
+  return keyIndex(KeyAddr(row, col));
 }
 
 constexpr byte R0C0  = keyIndex(0, 0);


### PR DESCRIPTION
Only merge this if and after https://github.com/keyboardio/Kaleidoscope/pull/589 has been merged.

This PR requires matrix addressing to be merged in Kaleidoscope. It adapts the
virtual hardware to matrix addressing.

Signed-off-by: Florian Fleissner <florian.fleissner@inpartik.de>